### PR TITLE
chore: don't pack `example/` and `test/` folders and other dev files

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,10 @@
 	},
 	"publishConfig": {
 		"ignore": [
-			".github/workflows"
+			".github/workflows",
+			"test",
+			"example",
+			".eslintrc"
 		]
 	}
 }


### PR DESCRIPTION
currently this package includes many files that aren't needed at runtime. This PR npmignores them
![image](https://github.com/ljharb/json-stable-stringify/assets/83948/e71c4b24-1088-4aa7-b8ec-8816ab5de699)

## Test Plan

run `npm pack`. You should see only these files packed
```
npm notice === Tarball Contents === 
npm notice 592B   .github/FUNDING.yml            
npm notice 6.6kB  CHANGELOG.md                   
npm notice 1.1kB  LICENSE                        
npm notice 4.1kB  README.md                      
npm notice 2.1kB  index.js                       
npm notice 38.8kB json-stable-stringify-1.0.2.tgz
npm notice 2.0kB  package.json       
```