### PR TITLE
Add get function to opts.cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If `opts` is given, you can supply an `opts.cmp` to have a custom comparison fun
 Your function `opts.cmp` is called with these parameters:
 
 ``` js
-opts.cmp({ key: akey, value: avalue }, { key: bkey, value: bvalue })
+opts.cmp({ key: akey, value: avalue }, { key: bkey, value: bvalue }, { get(key): value })
 ```
 
 For example, to sort on the object key names in reverse order you could write:
@@ -68,13 +68,13 @@ console.log(s);
 
 which results in the output string:
 
-```
+``` js
 {"c":8,"b":[{"z":6,"y":5,"x":4},7],"a":3}
 ```
 
 Or if you wanted to sort on the object values in reverse order, you could write:
 
-```
+``` js
 var stringify = require('json-stable-stringify');
 
 var obj = { d: 6, c: 5, b: [{ z: 3, y: 2, x: 1 }, 9], a: 10 };
@@ -88,9 +88,11 @@ console.log(s);
 
 which outputs:
 
-```
+``` js
 {"d":6,"c":5,"b":[{"z":3,"y":2,"x":1},9],"a":10}
 ```
+
+An additional param `get(key)` returns the value of the key from the object being currently compared.
 
 ### space
 

--- a/index.js
+++ b/index.js
@@ -15,10 +15,12 @@ module.exports = function (obj, opts) {
 
 	var cmpOpt = opts.cmp;
 	var cmp = cmpOpt && function (node) {
+		var get = cmpOpt.length > 2 && function get(k) { return node[k]; };
 		return function (a, b) {
 			return cmpOpt(
 				{ key: a, value: node[a] },
-				{ key: b, value: node[b] }
+				{ key: b, value: node[b] },
+				get ? { __proto__: null, get: get } : void undefined
 			);
 		};
 	};

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -11,3 +11,20 @@ test('custom comparison function', function (t) {
 	});
 	t.equal(s, '{"c":8,"b":[{"z":6,"y":5,"x":4},7],"a":3}');
 });
+
+test('custom comparison function with get', function (t) {
+	t.plan(2);
+
+	stringify({ a: 1, b: 2 }, function (a, b) { // eslint-disable-line no-unused-vars
+		t.equal(arguments[2], undefined, 'comparator options not passed when not explicitly requested');
+	});
+
+	var obj = { c: 8, b: [{ z: 7, y: 6, x: 4, v: 2, '!v': 3 }, 7], a: 3 };
+	var s = stringify(obj, function (a, b, options) {
+		var get = options.get;
+		var v1 = (get('!' + a.key) || 0) + a.value;
+		var v2 = (get('!' + b.key) || 0) + b.value;
+		return v1 - v2;
+	});
+	t.equal(s, '{"c":8,"b":[{"!v":3,"x":4,"v":2,"y":6,"z":7},7],"a":3}');
+});


### PR DESCRIPTION
Resolves #4. This is a minor version bump (non-breaking change).

Other recommendations to make this package more appealing and usable in the modern world:

- Add in-house TypeScript typings (or I'll patch [these](https://www.npmjs.com/package/@types/json-stable-stringify) afterwards)
- Delete all dependencies as not necessary to use:
   - `typeof JSON !== 'undefined'` -> JSON is everywhere now, no need to check it
   - `require('isarray')` is a one-liner `x instanceof Array`
   - `require('object-keys')` -> use `Object.keys`
- ES module & general refactoring would be nice.