### PR TITLE
[types] input can be non object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace stableStringify {
 }
 
 declare function stableStringify(
-    obj: object,
+    obj: unknown,
     options?: (stableStringify.Comparator & stableStringify.StableStringifyOptions) | stableStringify.StableStringifyOptions,
 ): string | undefined;
 

--- a/test/str.js
+++ b/test/str.js
@@ -32,3 +32,15 @@ test('array with empty string', function (t) {
 	var obj = [4, '', 6];
 	t.equal(stringify(obj), '[4,"",6]');
 });
+
+test('raw string', function (t) {
+	t.plan(1);
+	var input = 'raw';
+	t.equal(stringify(input), '"raw"');
+});
+
+test('raw number', function (t) {
+	t.plan(1);
+	var input = 42;
+	t.equal(stringify(input), '42');
+});


### PR DESCRIPTION
I like seeing the addition of types and type checks by the library itself!

Given that the [input can be a non-object](https://github.com/ljharb/json-stable-stringify/blob/4cff539ecf0310e7a1700d5a45f339a4038f139c/index.js#L73-L75) and `JSON.stringify` can also have a non object input, the typings should reflect that. Especially as json-stable-stringify can be more of a drop-in replacement of `JSON.stringify` then. (I noticed this as updating this library resulted in type errors for me as my input could be a string in some cases)

Both `JSON.stringify` and [`@types/json-stable-stringify`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/27cb7c70c65995302b5302fa8b7fd8bcda939423/types/json-stable-stringify/index.d.ts#L6) use `any` for this. Which is ok for providing typings for external code but worse for type checking the actual code with typescript. `any` allows doing all kinds of stuff, TypeScript just assumes that its probably ok, while `unknown` requires you to check the types before using them (which is done by this library). So TypeScript ensures the type checks are correct.

I also added tests that ensure that non-object input actually works both in JavaScript and have working typings (without the change to `unknown` TypeScript is unhappy). Not sure whether they are in the correct file. Should they get their own test file?