### PR TITLE
[New] add collapseEmpty option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare namespace stableStringify {
 
     type StableStringifyOptions = {
         cmp?: Comparator;
+        collapseEmpty?: boolean;
         cycles?: boolean;
         replacer?: (this: Node, key: Key, value: unknown) => unknown;
         space?: string | number;

--- a/test/space.js
+++ b/test/space.js
@@ -74,6 +74,31 @@ test('space parameter (same as native)', function (t) {
 	);
 });
 
+test('space parameter base empty behavior: empty arrays and objects have added newline and space', function (t) {
+	t.plan(1);
+	var obj = { emptyArr: [], emptyObj: {} };
+	t.equal(
+		stringify(obj, { space: '  ' }),
+		'{\n  "emptyArr": [\n  ],\n  "emptyObj": {\n  }\n}'
+	);
+});
+
+test('space parameter, with collapseEmpty: true', function (t) {
+	t.plan(2);
+	var obj = { emptyArr: [], emptyObj: {} };
+
+	t['throws'](
+		// @ts-expect-error
+		function () { stringify(obj, { collapseEmpty: 'not a boolean' }); },
+		TypeError
+	);
+
+	t.equal(
+		stringify(obj, { collapseEmpty: true, space: '  ' }),
+		'{\n  "emptyArr": [],\n  "emptyObj": {}\n}'
+	);
+});
+
 test('space parameter, on a cmp function', function (t) {
 	t.plan(3);
 	var obj = { one: 1, two: 2 };


### PR DESCRIPTION
New option to remove newlines in empty arrays and objects

Fixes #15 

This PR adds a new option, `collapseEmpty`, that can be passed when `stringify` is called. When `collapseEmpty` is `true`, empty arrays and empty objects within the output will not have indent characters inserted between their opening and closing brackets. The effect is that the empty brackets will appear next to each other on the same line as their key, even when `space` has been specified (which otherwise would lead to an indent with the space and a newline).

Example from the linked issue: output from `stringify({ a: [], b: {} }, { space: 2 })` currently looks like:
```json
{
  "a": [
  ],
  "b": {
  }
}
```

After these changes, `stringify({ a: [], b: {} }, { collapseEmpty: true, space: 2 })` will look like:
```json
{
  "a": [],
  "b": {}
}
```

`collapseEmpty` only matters when `space` has been specified, since the indent value otherwise is an empty string.

TODO: I'm happy to write the README entry for this once you've had a chance to review.



I do think there is a case to be made that this should be the default behavior, in order to maintain the same shape as JSON.stringify when given equivalent options. However, putting this behind a `collapseEmpty` option makes this behavior available without making a breaking change.

Note - I had initially checked if `collapseEmpty` was true inline in the places where it was needed, but this ran one unit past eslint's complexity threshold for the `stringify` function. I moved the grouping logic to its own closure to make the linter pass, but am happy to revert and adjust the linting rules instead if that's preferable.

Thanks for reviewing this, happy to make any changes!

